### PR TITLE
Create a dhcp server and a client that connects to it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# Created by https://www.gitignore.io/api/vagrant
+
+### Vagrant ###
+.vagrant/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,7 +7,7 @@ Vagrant.configure("2") do |config|
       dhcp_server.vm.network "private_network", ip: "192.168.33.10"
       dhcp_server.vm.hostname = "dhcp-srv"
       dhcp_server.vm.provider "virtualbox" do |vb|
-        vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "dhcp"]
+        vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "dhcp-srv"]
        end
       dhcp_server.vm.provision "shell", path: "scripts/dhcp.sh"
     end
@@ -18,7 +18,7 @@ Vagrant.configure("2") do |config|
         client.vm.network "private_network", ip: "192.168.33.2#{i}"
         client.vm.hostname = "dhcp-cli#{i}"
         client.vm.provider "virtualbox" do |vb|
-          vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "client"]
+          vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "dhcp-cli#{i}"]
          end
         client.vm.provision "shell", path: "scripts/client.sh"
       end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,23 +1,26 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 Vagrant.configure("2") do |config|
-
-  config.vm.provision :shell, inline: "echo ai"
-  (1..2).each do |i|
-   config.vm.define "web-#{i}" do |web|
-     web.vm.box = "centos/7"
-     web.vm.hostname = "web-#{i}"
-     web.vm.network "private_network", ip: "192.168.33.1#{i}"
-     web.vm.provider "virtualbox" do |vb|
-      vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "web-#{i}"]
-     end
-     web.vm.provision "file", source: "sources/", destination: "src"
-     web.vm.provision "shell", inline: "src/script.sh"
-   end
+    config.vm.define "dhcp-srv" do |dhcp_server|
+      dhcp_server.vm.box = "generic/ubuntu1804"
+      dhcp_server.vm.network "private_network", ip: "192.168.33.10"
+      dhcp_server.vm.hostname = "dhcp-srv"
+      dhcp_server.vm.provider "virtualbox" do |vb|
+        vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "dhcp"]
+       end
+      dhcp_server.vm.provision "shell", path: "scripts/dhcp.sh"
+    end
+    
+    (1..1).each do |i|
+      config.vm.define "dhcp-cli" do |client|
+        client.vm.box = "generic/ubuntu1804"
+        client.vm.network "private_network", ip: "192.168.33.2#{i}"
+        client.vm.hostname = "dhcp-cli#{i}"
+        client.vm.provider "virtualbox" do |vb|
+          vb.customize ["modifyvm", :id, "--memory", "512", "--cpus", "1", "--name", "client"]
+         end
+        client.vm.provision "shell", path: "scripts/client.sh"
+      end
+    end
   end
-
-  config.vm.define "db" do |db|
-   db.vm.box = "centos/7"
-   db.vm.provision "shell", inline: "echo c"
-  end
-
-  config.vm.provision :shell, inline: "echo d"
-end

--- a/scripts/client.sh
+++ b/scripts/client.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+# Stop any existing DHCP client
+sudo dhclient -r
+
+# Request new IP address from DHCP server
+sudo dhclient -d -s "192.168.33.10" -v "eth1"

--- a/scripts/dhcp.sh
+++ b/scripts/dhcp.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# Install DHCP server package
+sudo apt-get update
+sudo apt-get install -y isc-dhcp-server
+
+# Configure DHCP server
+sudo sed -i 's/INTERFACESv4=""/INTERFACESv4="eth1"/g' /etc/default/isc-dhcp-server
+sudo cat > /etc/dhcp/dhcpd.conf <<EOF
+# DHCP Server Configuration file
+# see /usr/share/doc/dhcp-server/dhcpd.conf.example
+# This file was created by the script
+
+# option definitions common to all supported networks
+option domain-name "example.com";
+option domain-name-servers ns1.example.com, ns2.example.com;
+
+default-lease-time 600;
+max-lease-time 7200;
+
+# Use this to enble/disable dynamic dns updates globally.
+#ddns-update-style none;
+
+# If this DHCP server is the official DHCP server for the local
+# network, the authoritative directive should be uncommented.
+authoritative;
+
+# Use this to send dhcp log messages to a different log file (you also
+# have to hack syslog.conf to complete the redirection).
+log-facility local7;
+
+# Define network
+subnet 192.168.33.0 netmask 255.255.255.0 {
+  range 192.168.33.100 192.168.33.200;
+  option routers 192.168.33.1;
+}
+EOF
+
+# Restart DHCP server
+sudo systemctl restart isc-dhcp-server.service


### PR DESCRIPTION
Edited the Vagrantfile to instance a DHCP server and a set of clients that connects to it.

- Currently, the number of clients is set to 1.
- Before running the vagrant up command, the scripts might need execution permissions (chmod +x).
- The client IPs will be initially set at "192.168.33.2#{ i }", then they will request another IP from the DHCP server and set it as a  "scope global secondary" on the eth1 interface.
